### PR TITLE
更新API服务器URL以指向新的域名

### DIFF
--- a/default_api_setting.json
+++ b/default_api_setting.json
@@ -1,5 +1,5 @@
 {
-    "server_api_url": "https://bluecraft-api.pages.dev/Python_Downloader_API/Get_API.json",
+    "server_api_url": "https://bc-api.xn--dyv4b972j7ga.com/Python_Downloader_API/Get_API.json",
     "server_api_url_gh": "https://Bluecraft-Server.github.io/API/Python_Downloader_API/Get_API.json",
     "Server_Name": "Bluecraft",
     "cf_mirror_enabled": true


### PR DESCRIPTION
此更改涉及更新Python_Downloader_API的server_api_url，将其从bluecraft-api.pages.dev更改为bc-api.xn--dyv4b972j7ga.com，以指向新的API服务器位置。